### PR TITLE
Add surefire plugin to enable JUnit 5 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,4 +27,14 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
## Summary
- configure Maven Surefire plugin so JUnit 5 tests run

## Testing
- `mvn test` *(fails: could not resolve maven-resources-plugin – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684445ce2d9c8331b607b94f473040ea