### PR TITLE
Fix orbit period calculation

### DIFF
--- a/earth_and _satellites_by_TLE.html
+++ b/earth_and _satellites_by_TLE.html
@@ -1095,13 +1095,13 @@
         removeAllGeometry();
         if (!simParams.showOrbit || !satData || !satData.satrec) return;
 
-        const meanMotion = satData.satrec.no;             // revs / min
+        const meanMotion = satData.satrec.no;             // radians per minute
         if (meanMotion === 0) {
             console.warn(`${satData.satellite_name} has zero mean motion.`);
             return;
         }
 
-        const periodMins = 1440 / meanMotion;             // minutes per revolution
+        const periodMins = (2 * Math.PI) / meanMotion;    // minutes per revolution
         const segments = 14400;                         // resolution
         const stepMin = periodMins / segments;
 

--- a/index.html
+++ b/index.html
@@ -1095,13 +1095,13 @@
         removeAllGeometry();
         if (!simParams.showOrbit || !satData || !satData.satrec) return;
 
-        const meanMotion = satData.satrec.no;             // revs / min
+        const meanMotion = satData.satrec.no;             // radians per minute
         if (meanMotion === 0) {
             console.warn(`${satData.satellite_name} has zero mean motion.`);
             return;
         }
 
-        const periodMins = 1440 / meanMotion;             // minutes per revolution
+        const periodMins = (2 * Math.PI) / meanMotion;    // minutes per revolution
         const segments = 14400;                         // resolution
         const stepMin = periodMins / segments;
 

--- a/test2.html
+++ b/test2.html
@@ -1423,12 +1423,12 @@
     function updateOrbitTrajectory(satData) {
         removeAllGeometry();
         if (!simParams.showOrbit || !satData || !satData.satrec) return;
-        const meanMotion = satData.satrec.no;
+        const meanMotion = satData.satrec.no;             // radians per minute
         if (meanMotion === 0) {
             console.warn(`${satData.satellite_name} has zero mean motion.`);
             return;
         }
-        const periodMins = 1440 / meanMotion;
+        const periodMins = (2 * Math.PI) / meanMotion;
         const segments = 14400;
         const step = periodMins / segments;
         const orbitPoints = [];


### PR DESCRIPTION
## Summary
- fix orbit period calculation when using satellite.js output
- mark satrec.no as radians per minute

## Testing
- `npm test` *(fails: missing script)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844721cd75083318e6c8ddfc67fe4fd