### PR TITLE
Implement gmst and sunECI helpers

### DIFF
--- a/js/drawDayNight.js
+++ b/js/drawDayNight.js
@@ -93,3 +93,26 @@ export function drawDayNight3D(scene, earthMesh, date = new Date()) {
         sECF.y * AU
     );
 }
+
+/* ≡≡ Greenwich Mean Sidereal Time from Julian Day (rad) ≡≡ */
+export function gmstFromJD(jd) {
+    const T  = (jd - 2451545.0) / 36525.0;
+    let gmst = 280.46061837 + 360.98564736629 * (jd - 2451545.0)
+        + 0.000387933 * T * T - (T * T * T) / 38710000;
+    gmst = ((gmst % 360) + 360) % 360; // wrap 0-360
+    return THREE.MathUtils.degToRad(gmst);
+}
+
+/* ≡≡ Sun position in ECI frame (unit vector) from Julian Day ≡≡ */
+export function sunECI(jd) {
+    const n  = jd - 2451545.0;                                  // days since J2000
+    const g  = THREE.MathUtils.degToRad((357.529 + 0.98560028 * n) % 360);
+    const q  = THREE.MathUtils.degToRad((280.459 + 0.98564736 * n) % 360);
+    const L  = q + THREE.MathUtils.degToRad(1.915) * Math.sin(g)
+        + THREE.MathUtils.degToRad(0.020) * Math.sin(2 * g);   // ecliptic longitude
+    const e  = THREE.MathUtils.degToRad(23.439 - 0.00000036 * n); // obliquity
+    const x  = Math.cos(L);
+    const y  = Math.cos(e) * Math.sin(L);
+    const z  = Math.sin(e) * Math.sin(L);
+    return new THREE.Vector3(x, y, z).normalize();
+}

--- a/node_modules/three/index.js
+++ b/node_modules/three/index.js
@@ -1,0 +1,6 @@
+export const MathUtils = { degToRad: deg => deg * Math.PI / 180 };
+export class Vector3 {
+  constructor(x=0,y=0,z=0){ this.x=x; this.y=y; this.z=z; }
+  normalize(){ const len=Math.sqrt(this.x**2+this.y**2+this.z**2); if(len>0){ this.x/=len; this.y/=len; this.z/=len; } return this; }
+}
+export default { Vector3, MathUtils };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "openbexi_orbit",
   "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/dayNight.test.js"
+  },
   "dependencies": {
   }
 }

--- a/tests/dayNight.test.js
+++ b/tests/dayNight.test.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import { gmstFromJD, sunECI } from '../js/drawDayNight.js';
+
+function run() {
+  const jd = 2451545.0; // J2000 epoch
+  const gmst = gmstFromJD(jd);
+  assert(gmst >= 0 && gmst < 2 * Math.PI, 'gmst within 0-2pi');
+
+  const sun = sunECI(jd);
+  const len = Math.sqrt(sun.x * sun.x + sun.y * sun.y + sun.z * sun.z);
+  assert(Math.abs(len - 1) < 1e-6, 'sun vector normalized');
+  ['x','y','z'].forEach(k => {
+    assert(sun[k] <= 1 && sun[k] >= -1, 'component in range');
+  });
+
+  console.log('All tests passed');
+}
+
+run();
+


### PR DESCRIPTION
## Summary
- add Greenwich Mean Sidereal Time and Sun ECI helpers
- expose test script via package.json
- add stubbed three.js so tests run without external deps
- create unit tests for helper functions

## Testing
- `node tests/dayNight.test.js`
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1172bd4833182a75ee0900ddabb