### PR TITLE
Handle empty footprints gracefully

### DIFF
--- a/js/satelliteFootprintLoader.js
+++ b/js/satelliteFootprintLoader.js
@@ -93,6 +93,10 @@ function buildEntry(sat) {
 }
 
 function parseFootprints(fp) {
+    if (!fp || (Array.isArray(fp) && fp.length === 0) ||
+        (typeof fp === 'object' && !Array.isArray(fp) && Object.keys(fp).length === 0)) {
+        return [];
+    }
     if (Array.isArray(fp.features)) {
         return fp.features.flatMap(f => geoFeatureToPolys(f));
     }


### PR DESCRIPTION
## Summary
- return early in `parseFootprints` if argument is empty

## Testing
- `npm test`
- node check for warnings when footprints missing

------
https://chatgpt.com/codex/tasks/task_e_68584f2949948331b257533dc92bc513