### PR TITLE
Fix moving footprint coverage for Mercator

### DIFF
--- a/index.html
+++ b/index.html
@@ -983,7 +983,10 @@
 
         /*── 👣 Footprint ───────────────────────────────────────────*/
         if (simParams.showFootprint) {
-            updateFootprints(currentSelectedSatellite, gmstNow, { showFootprint: true, mercatorCtx: null }
+            updateFootprints(
+                currentSelectedSatellite,
+                gmstNow,
+                { showFootprint: true, mercatorCtx: null, simDate: simNow }
             );
         }
         /*───────────────────────────────────────────────────────────*/
@@ -1017,7 +1020,11 @@
                     }
                     updateMercatorMap(simParams);
                     if (simParams.showFootprint) {
-                        updateFootprints(currentSelectedSatellite, gmstNow, { showFootprint: true, mercatorCtx });
+                        updateFootprints(
+                            currentSelectedSatellite,
+                            gmstNow,
+                            { showFootprint: true, mercatorCtx, simDate: simNow }
+                        );
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
- ensure footprint updates use current simulation time when rendering on 3D and Mercator map

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68587874c6fc8331b7e5121ff26c49bb